### PR TITLE
Default Speed Configuration, Reload Config, Spigot Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 [![GitHub Release](https://img.shields.io/github/v/release/certainly1182/FastMinecarts?include_prereleases)](https://github.com/certainly1182/FastMinecarts/releases)
 [![Modrinth Downloads](https://img.shields.io/modrinth/dt/######)](https://modrinth.com/plugin/######)
 
-Simple plugin for Minecraft [Paper](https://papermc.io) servers that changes the speed of minecarts depending on the block beneath the rails.
+Simple plugin for Minecraft [Spigot](https://spigotmc.org) servers that changes the speed of minecarts depending on the block beneath the rails.
 
 ## Features
 - Configure which blocks affect speed.
 - Choose the minecart speed for each block.
-- Slow minecarts back to vanilla speed when player disembarks.
+- Slow minecarts back to vanilla speed when the player disembarks.
 ## Installation
 To install FastMinecarts, follow these steps:
 1. Download the plugin JAR file from [Modrinth](https://modrinth.com/plugin/#####) or the [Releases](https://github.com/certainly1182/FastMinecarts/releases) page.
-2. Place the JAR file in the plugins folder of your Paper (or Paper fork) server.
+2. Place the JAR file in the plugins folder of your Spigot (or Spigot fork) server.
 3. Start the server and verify that the plugin loaded successfully.
 ## Configuration
-The plugin can be configured via the `config.yml` file located in `plugins/FastMinecarts`.
+The plugin can be configured via the `config.yml` file in `plugins/FastMinecarts`.
 
 The following configuration options are available:
 
@@ -24,11 +24,12 @@ The following configuration options are available:
 # List of blocks and their corresponding maximum minecart speeds
 # Blocks must be from https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
 # The default minecart speed is 0.4
+default-speed: 2.0
 blocks:
-  GRAVEL: 0.8
+  COARSE_DIRT: 0.4
   SOUL_SAND: 0.2
 ```
 ## Usage
-The FastMinecarts plugin does not *yet* have any commands or permissions. Simply install and configure the plugin on your server to start using it.
+The FastMinecarts plugin has the command "/FastMinecarts Reload" and it requires the permission: "FastMinecarts.reload" but also can be run by an op. Simply install and configure the plugin on your server to start using it.
 
-When a player enters a minecart on rails above configured blocks, the speed is modified.
+The speed is modified when a player enters a minecart on rails above configured blocks.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # FastMinecarts Plugin
 [![GitHub Release](https://img.shields.io/github/v/release/certainly1182/FastMinecarts?include_prereleases)](https://github.com/certainly1182/FastMinecarts/releases)
-[![Modrinth Downloads](https://img.shields.io/modrinth/dt/######)](https://modrinth.com/plugin/######)
+<!--- [![Modrinth Downloads](https://img.shields.io/modrinth/dt/######)](https://modrinth.com/plugin/######) -->
 
-Simple plugin for Minecraft [Spigot](https://spigotmc.org) servers that changes the speed of minecarts depending on the block beneath the rails.
+A simple plugin for Minecraft [Spigot](https://spigotmc.org) servers that allows you to change the speed of minecarts depending on the block beneath the rails or globally.
 
 ## Features
+- Configure the global speed.
 - Configure which blocks affect speed.
 - Choose the minecart speed for each block.
 - Slow minecarts back to vanilla speed when the player disembarks.
 ## Installation
 To install FastMinecarts, follow these steps:
-1. Download the plugin JAR file from [Modrinth](https://modrinth.com/plugin/#####) or the [Releases](https://github.com/certainly1182/FastMinecarts/releases) page.
+1. Download the plugin JAR file from<!--- [Modrinth](https://modrinth.com/plugin/#####)  or the--> [Releases](https://github.com/certainly1182/FastMinecarts/releases) page.
 2. Place the JAR file in the plugins folder of your Spigot (or Spigot fork) server.
 3. Start the server and verify that the plugin loaded successfully.
 ## Configuration
@@ -30,6 +31,6 @@ blocks:
   SOUL_SAND: 0.2
 ```
 ## Usage
-The FastMinecarts plugin has the command "/FastMinecarts Reload" and it requires the permission: "FastMinecarts.reload" but also can be run by an op. Simply install and configure the plugin on your server to start using it.
+The FastMinecarts plugin has the command "/FastMinecarts Reload" to reload the config, and it requires the permission: "FastMinecarts.reload" but also can be run by an op. Simply install and configure the plugin on your server to start using it.
 
-The speed is modified when a player enters a minecart on rails above configured blocks.
+The global speed gets applied when a player enters a minecart on rails, and when you ride the minecart above the configured blocks it will change the speed to the configured value.

--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,28 @@
 
     <groupId>me.certainly1182</groupId>
     <artifactId>FastMinecarts</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>FastMinecarts</name>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.8.10</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -56,32 +65,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>17</jvmTarget>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>testCompile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <jvmTarget>1.8</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>
@@ -95,8 +79,8 @@
 
     <repositories>
         <repository>
-            <id>papermc-repo</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>sonatype</id>
@@ -106,9 +90,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.certainly1182</groupId>
     <artifactId>FastMinecarts</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>FastMinecarts</name>

--- a/src/main/java/me/certainly1182/fastminecarts/FastMinecarts.kt
+++ b/src/main/java/me/certainly1182/fastminecarts/FastMinecarts.kt
@@ -2,6 +2,10 @@ package me.certainly1182.fastminecarts
 
 import org.bukkit.Bukkit
 import org.bukkit.Material
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
 import org.bukkit.entity.Minecart
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -10,19 +14,22 @@ import org.bukkit.event.vehicle.VehicleExitEvent
 import org.bukkit.event.vehicle.VehicleMoveEvent
 import org.bukkit.plugin.java.JavaPlugin
 
-class FastMinecarts : JavaPlugin(), Listener {
-    private val VANILLA_MAX_SPEED = 0.4
+class FastMinecarts : JavaPlugin(), Listener, CommandExecutor, TabCompleter {
+    private var VANILLA_MAX_SPEED = 0.4
     private var _blockMaxSpeeds = mutableMapOf<Material, Double>()
     private val railTypes = listOf(
-        Material.RAIL, Material.POWERED_RAIL,
-        Material.DETECTOR_RAIL, Material.ACTIVATOR_RAIL
+            Material.RAIL, Material.POWERED_RAIL,
+            Material.DETECTOR_RAIL, Material.ACTIVATOR_RAIL
     )
     override fun onEnable() {
         saveDefaultConfig()
         loadConfig()
         Bukkit.getPluginManager().registerEvents(this, this)
+        getCommand("FastMinecarts")?.setExecutor(this)
+        getCommand("FastMinecarts")?.tabCompleter = this
     }
     private fun loadConfig() {
+        VANILLA_MAX_SPEED = config.getDouble("default-speed", 0.4)
         val blockConfig = config.getConfigurationSection("blocks") ?: return
         _blockMaxSpeeds.clear()
         for (key in blockConfig.getKeys(false)) {
@@ -57,5 +64,30 @@ class FastMinecarts : JavaPlugin(), Listener {
         if (minecart.maxSpeed > VANILLA_MAX_SPEED) {
             minecart.maxSpeed = VANILLA_MAX_SPEED
         }
+    }
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<String>): Boolean {
+        if (command.name.equals("FastMinecarts", ignoreCase = true)) {
+            if (sender.hasPermission("FastMinecarts.reload")) {
+                if (args.isNotEmpty() && args[0].equals("reload", ignoreCase = true)) {
+                    reloadConfig()
+                    loadConfig()
+                    sender.sendMessage("§aFastMinecarts configuration reloaded.")
+                    return true
+                }
+            } else {
+                sender.sendMessage("§cYou do not have permission to reload FastMinecarts.")
+            }
+        }
+        return false
+    }
+
+    override fun onTabComplete(sender: CommandSender, command: Command, alias: String, args: Array<String>): List<String>? {
+        if (command.name.equals("FastMinecarts", ignoreCase = true)) {
+            if (args.size == 1) {
+                return listOf("reload").filter { it.startsWith(args[0], ignoreCase = true) }
+            }
+        }
+        return null
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 # List of blocks and their corresponding maximum minecart speeds
 # Blocks must be from https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
 # The default minecart speed is 0.4
+default-speed: 2.0
 blocks:
-  GRAVEL: 0.8
+  COARSE_DIRT: 0.4
   SOUL_SAND: 0.2

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,7 @@
 name: FastMinecarts
 version: '${project.version}'
 main: me.certainly1182.fastminecarts.FastMinecarts
-api-version: 1.19
+api-version: '1.19'
+commands:
+  FastMinecarts:
+    description: Reloads the FastMinecarts plugin


### PR DESCRIPTION
You can now set the default speed that the minecarts should go.

Added a /FastMinecarts Reload Command that uses the permission: "FastMinecarts.reload" but it can also be run by an op.

It now runs on the spigot API because there was no need for the paper one and gives more compatibility for other servers.